### PR TITLE
Add generic start page

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -6,17 +6,21 @@ site:
   title: OpenNMS // Docs
   # the 404 page and sitemap files only get generated when the url property is set
   url: https://docs.opennms.org
-  start_page: helm::index.adoc
+  start_page: start-page::index.adoc
   robots: allow
 content:
   sources:
+  # Generic start page
+  - url: .
+    start_path: start-page
+    branches: HEAD
   - url: https://github.com/OpenNMS/opennms.git
-    branches: jira/NMS-12497
     start_path: docs
+    branches: jira/NMS-12497
   # embedding empty credentials in the URL disables the Edit this Page link for any page created from this repository
   - url: https://github.com/opennms/opennms-helm.git
-    branches: develop
     start_path: docs
+    branches: develop
     tags:
     - v*
     - '!v5.0.1'
@@ -26,9 +30,9 @@ content:
     - '!v2*'
     - '!v1*'
   - url: https://github.com/OpenNMS/alec.git
+    start_path: docs
     branches: develop
     tags: v*
-    start_path: docs
   - url: https://github.com/OpenNMS/opennms-provisioning-integration-server.git
     start_path: docs
     branches:
@@ -48,6 +52,7 @@ asciidoc:
     idseparator: '-'
     page-pagination: ''
     source-language: asciidoc@
+    distribution: 'Horizon'
 output:
   clean: true
   dir: ./public

--- a/start-page/antora.yml
+++ b/start-page/antora.yml
@@ -1,0 +1,3 @@
+name: start-page
+version: '1.0.0'
+title: Start Page

--- a/start-page/modules/ROOT/pages/index.adoc
+++ b/start-page/modules/ROOT/pages/index.adoc
@@ -1,0 +1,14 @@
+# Welcome to the OpenNMS Documentation
+
+OpenNMS is a scalable and highly configurable network management platform with comprehensive fault, performance, and traffic monitoring. 
+It easily integrates with your core business applications and workflows to monitor and visualize everything in your network.
+
+This documentation includes information on the following products:
+
+* OpenNMS {distribution}
+** Core (server that drives {distribution})
+** Minion (for application perspective monitoring)
+** Sentinel (for scalability) 
+* Helm (for customized dashboards)
+* Architecture for Learning Enabled Correlation (ALEC) (for alarm triage)
+* Provisioning Integration Server (PRIS) (for integrating extracted data)


### PR DESCRIPTION
I've investigated two options to add a generic start page. Number one is without a navigation bar. The version numbers at the bottom are expanded by default when you enter the page. See here:

![Screenshot 2020-06-08 at 12 11 16](https://user-images.githubusercontent.com/1095181/84019162-35fefc80-a981-11ea-8c0b-76a5d7d34344.png)

If we add navigation, the version number selection is collapsed when we enter the page.

![Screenshot 2020-06-08 at 12 18 05](https://user-images.githubusercontent.com/1095181/84019831-203e0700-a982-11ea-9bff-121c193096b3.png)

IMHO I would prefer version one.