### PR TITLE
add OpenNMS.js

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -43,6 +43,13 @@ content:
   - url: https://github.com/OpenNMS/opennms-js.git
     start_path: docs-src
     branches: ranger/docs
+    tags:
+    - v*
+    - '!v0.*'
+    - '!v1.*'
+    - '!v2.0.0'
+    - '!v2.0.1'
+    - '!v2.0.2'
 ui:
   bundle:
     url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v1.3.0/ui-bundle.zip

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -42,7 +42,7 @@ content:
       - '!release-1.0*'
   - url: https://github.com/OpenNMS/opennms-js.git
     start_path: docs-src
-    branches: ranger/docs
+    branches: develop
     tags:
     - v*
     - '!v0.*'


### PR DESCRIPTION
For when https://github.com/OpenNMS/opennms-js/pull/206 is reviewed and merged, this will enable OpenNMS.js docs in Antora. I think.