### PR TITLE
NMS-13862: Fix the sitemap.xml URL base

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -6,7 +6,7 @@ runtime:
 site:
   title: Docs
   # the 404 page and sitemap files only get generated when the url property is set
-  url: https://www.opennms.com/
+  url: https://docs.opennms.com/
   start_page: start-page::index.adoc
   robots: allow
 content:
@@ -59,7 +59,7 @@ content:
     - '!v2.0.2'
 ui:
   bundle:
-    url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v2.0.4/ui-bundle.zip
+    url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v2.0.6/ui-bundle.zip
     snapshot: true
   supplemental_files: ./supplemental-ui
 asciidoc:


### PR DESCRIPTION
The sitemap URL base is taken from the Antora URL. The Antora UI 2.0.6 fixes the links in the main navbar going to our opennms.com website and allows us to use docs.opennms.com as the base URL for the sitemap.xml generation correctly.

JIRA: https://issues.opennms.org/browse/NMS-13862