### PR TITLE
NMS-14637: Remove footer content from opennms/docs.opennms.com

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -72,7 +72,7 @@ content:
     - '!v2.0.2'
 ui:
   bundle:
-    url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v2.0.6/ui-bundle.zip
+    url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v3.0.1/ui-bundle.zip
     snapshot: true
   supplemental_files: ./supplemental-ui
 asciidoc:

--- a/start-page/modules/ROOT/pages/index.adoc
+++ b/start-page/modules/ROOT/pages/index.adoc
@@ -1,7 +1,7 @@
 # Welcome to the OpenNMS Documentation
 
-OpenNMS is an open source solution that helps you visualize and monitor everything on your local and remote networks. 
-It offers comprehensive fault, performance, traffic monitoring, and alarm generation in one place. 
+OpenNMS is an open source solution that helps you visualize and monitor everything on your local and remote networks.
+It offers comprehensive fault, performance, traffic monitoring, and alarm generation in one place.
 Highly customizable and scalable, OpenNMS easily integrates with your core business applications and workflows.
 
 *Components*
@@ -9,14 +9,14 @@ Highly customizable and scalable, OpenNMS easily integrates with your core busin
 * OpenNMS {distribution}
 ** Core (server that drives {distribution})
 ** Minion (distritubed monitoring)
-** Sentinel (scalability) 
+** Sentinel (scalability)
 * Helm (customized dashboards)
 * Architecture for Learning Enabled Correlation (ALEC) (alarm triage)
 * Provisioning Integration Server (PRIS) (extracted data integration)
 
 == About this documentation
 
-This documentation includes information on the OpenNMS components listed above, including deployment, configuration, use, and maintenance. 
+This documentation includes information on the OpenNMS components listed above, including deployment, configuration, use, and maintenance.
 
 === Audience
 Suitable for administrative users and those who will use OpenNMS to monitor their network.    

--- a/supplemental-ui/partials/footer-content.hbs
+++ b/supplemental-ui/partials/footer-content.hbs
@@ -1,5 +1,0 @@
-<footer class="footer">
-  <p>Copyright (c) The OpenNMS Group, Inc.</p>
-  <p>Licensed under the terms of the AGPL-3.0.</p>
-  <p> Legal Notice</p>
-</footer>


### PR DESCRIPTION
NMS-14637: Remove footer content from opennms/docs.opennms.com - removed footer content, as it would overwrite footer content that specifies the copyright date and had link to legal notice, as per reviewer feedback on NMS-13911

JIRA: https://issues.opennms.org/browse/NMS-13911