### PR TITLE
docs: Remove H29 with release of H31

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -25,6 +25,7 @@ content:
     start_path: docs
     branches:
       - 'master-*'
+      - '!master-29'
       - '!master-28'
       - '!master-27'
       - '!master-26'


### PR DESCRIPTION
With Horizon we publish only official docs for the latest stable release. However it takes some time for people to upgrade, we publish the docs for the recent major version as well. I think the pattern we want to follow here is the current stable release and the last stable release.

<img width="1715" alt="Screenshot 2022-11-10 at 11 27 12" src="https://user-images.githubusercontent.com/1095181/201067089-10b65c7f-0517-4a94-ab8f-71ec3e824048.png">
