### PR TITLE
NMS-13540: Highlight search terms in result page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   docs-executor:
     docker:
-      - image: opennms/antora:3.1.1-b8850
+      - image: opennms/antora:3.1.1-b9148
   publish-executor:
     docker:
       - image: circleci/buildpack-deps:focal

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "devDependencies": {
         "@antora/cli": "3.1.1",
-        "@antora/lunr-extension": "1.0.0-alpha.8",
+        "@antora/lunr-extension": "https://github.com/opennms-forge/antora-lunr-extension.git",
         "@antora/site-generator": "3.1.1"
       }
     },
@@ -137,8 +137,7 @@
     },
     "node_modules/@antora/lunr-extension": {
       "version": "1.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@antora/lunr-extension/-/lunr-extension-1.0.0-alpha.8.tgz",
-      "integrity": "sha512-vdBgW3rsvbnmA236kT2Dckh9n0Db5za2/WxiLnFLgZ05ZO1KJQa9+R2WHaIFuGE7bKKbY+lqfM/i3KiezbL9YQ==",
+      "resolved": "git+https://github.com/opennms-forge/antora-lunr-extension.git#7a9fd2bb9b19117475290fddc0d4e1c4217afb26",
       "dev": true,
       "dependencies": {
         "cheerio": "1.0.0-rc.10",
@@ -2630,9 +2629,8 @@
       }
     },
     "@antora/lunr-extension": {
-      "version": "1.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@antora/lunr-extension/-/lunr-extension-1.0.0-alpha.8.tgz",
-      "integrity": "sha512-vdBgW3rsvbnmA236kT2Dckh9n0Db5za2/WxiLnFLgZ05ZO1KJQa9+R2WHaIFuGE7bKKbY+lqfM/i3KiezbL9YQ==",
+      "version": "git+https://github.com/opennms-forge/antora-lunr-extension.git#7a9fd2bb9b19117475290fddc0d4e1c4217afb26",
+      "from": "git+https://github.com/opennms-forge/antora-lunr-extension.git",
       "dev": true,
       "requires": {
         "cheerio": "1.0.0-rc.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "@antora/cli": "3.1.1",
-    "@antora/lunr-extension": "1.0.0-alpha.8",
+    "@antora/lunr-extension": "https://github.com/opennms-forge/antora-lunr-extension.git",
     "@antora/site-generator": "3.1.1"
   }
 }


### PR DESCRIPTION
This changes the version of `antora-lunr-extension` to our own for which implements the required functionality: https://github.com/opennms-forge/antora-lunr-extension.

To use the changes in `antora-lunr-extension`, the builder image has to be updated, too.
See https://github.com/opennms-forge/opennms-base-container/pull/26.

In addition, a PR for upstream has been created: https://gitlab.com/antora/antora-lunr-extension/-/merge_requests/90.