### PR TITLE
NMS-15531: Docs lower footer needs copyright year bump

### DIFF
--- a/start-page/modules/ROOT/pages/legal-notice.adoc
+++ b/start-page/modules/ROOT/pages/legal-notice.adoc
@@ -1,5 +1,5 @@
 OpenNMS is the creation of numerous people and organizations, operating under the umbrella of the OpenNMS project.
-The source code is published under the GNU Affero GPL, version 3 or later and is Copyright © 2002-{docyear} The OpenNMS Group, Inc.
+The source code is published under the GNU Affero GPL, version 3 or later and is Copyright © 2015-2023 The OpenNMS Group, Inc.
 
 The current corporate sponsor of OpenNMS is The OpenNMS Group, which also owns the OpenNMS trademark.
 
@@ -8,4 +8,4 @@ Please report any omissions or corrections to this document by creating an issue
 Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.1 or any later version published by the Free Software Foundation; with no Invariant Sections, with no Front-Cover Texts and with no Back-Cover Texts.
 A copy of the license is available at http://www.gnu.org/copyleft/fdl.html
 
-Copyright (C) 2002-{docyear} The OpenNMS Group, Inc.
+Copyright (C) 2015-2023 The OpenNMS Group, Inc.

--- a/start-page/modules/ROOT/pages/legal-notice.adoc
+++ b/start-page/modules/ROOT/pages/legal-notice.adoc
@@ -1,11 +1,11 @@
 OpenNMS is the creation of numerous people and organizations, operating under the umbrella of the OpenNMS project.
-The source code is published under the GNU Affero GPL, version 3 or later and is Copyright © 2015-2023 The OpenNMS Group, Inc.
+The source code is published under the GNU Affero GPL, version 3 or later, and is Copyright © 2015-2023 The OpenNMS Group, Inc.
 
 The current corporate sponsor of OpenNMS is The OpenNMS Group, which also owns the OpenNMS trademark.
 
 Please report any omissions or corrections to this document by creating an issue at http://issues.opennms.org.
 
-Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.1 or any later version published by the Free Software Foundation; with no Invariant Sections, with no Front-Cover Texts and with no Back-Cover Texts.
+Permission is granted to copy, distribute, and/or modify this document under the terms of the GNU Free Documentation License, version 1.1 or any later version published by the Free Software Foundation; with no Invariant Sections, with no Front-Cover Texts, and with no Back-Cover Texts.
 A copy of the license is available at http://www.gnu.org/copyleft/fdl.html
 
 Copyright (C) 2015-2023 The OpenNMS Group, Inc.


### PR DESCRIPTION
Updated the copyright year for the docs. Hard-coded, as variable wasn't working.