### PR TITLE
Updating antora-playbook.yml with a temporary fix

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -56,6 +56,8 @@ content:
       - /^main-.*/
     tags:
       - v*
+      - '!v9.0.0-2'
+      - '!v9.0.0'
       - '!v8.0.3'
       - '!v8.0.2'
       - '!v8.0.1'
@@ -94,7 +96,8 @@ content:
       - main
       - /^release-.*/
     tags:
-    - v*
+      - v*
+      - '!v1.0.0'
   - url: https://github.com/OpenNMS/opennms-provisioning-integration-server.git
     start_path: docs
     branches:


### PR DESCRIPTION
This is a temporary fix, and its intent is to get the build running again!


The latest docs.opennms.com is failing since Grafana Plugin has two v9.0.0 tags; I'm filtering v9.0.0 and v9.0.0-2 tags for Grafana;

In addition, I'm filtering v1.0.0 tag for Velocloud as that tag contains `1.0.0-SNAPSHOT` in the docs.
