### PR TITLE
HS-420: Fix build for Grafana plugin for latest 8.x and 9.x release

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -51,31 +51,8 @@ content:
   - url: https://github.com/opennms/grafana-plugin.git
     start_path: docs
     branches:
-      - develop
-      - /^release-.*/
-      - /^main-.*/
-    tags:
-      - v*
-      - '!v9.0.0-2'
-      - '!v9.0.0'
-      - '!v8.0.3'
-      - '!v8.0.2'
-      - '!v8.0.1'
-      - '!v8.0.0'
-      - '!v7.3.0'
-      - '!v7.2.*'
-      - '!v7.1.*'
-      - '!v7.0.*'
-      - '!v6.0.1'
-      - '!v6.0.0'
-      - '!v5.0.3'
-      - '!v5.0.2'
-      - '!v5.0.1'
-      - '!v5.0.0'
-      - '!v4.*'
-      - '!v3.*'
-      - '!v2.*'
-      - '!v1.*'
+      - 'main-9'
+      - 'main-8'
   - url: https://github.com/OpenNMS/alec.git
     start_path: docs
     branches:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -51,8 +51,8 @@ content:
   - url: https://github.com/opennms/grafana-plugin.git
     start_path: docs
     branches:
-      - 'main-9'
-      - 'main-8'
+      - 'main-*'
+      - '!main-7'
   - url: https://github.com/OpenNMS/alec.git
     start_path: docs
     branches:


### PR DESCRIPTION
Set the build branches to main-8 and main-9 which reflect the latest major releases.

JIRA: https://opennms.atlassian.net/browse/HELM-420