### PR TITLE
NMS-15624: k8s: docs: add documentation to docs website

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -71,10 +71,6 @@ content:
     start_path: docs
     branches:
       - main
-      - /^release-.*/
-    tags:
-      - v*
-      - '!v1.0.0'
   - url: https://github.com/OpenNMS/opennms-velocloud-plugin.git
     start_path: docs
     branches:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -67,6 +67,14 @@ content:
       - '!v2.0.0.alpha0' # same SNAPSHOT version as another branch
       - '!v1.1.1' # Tag v1.1.1 has version number 1.1.1-SNAPSHOT use v1.1.1-doc instead
       - '!v1.1.1-rebuild' # I thought I needed to remake the debs, but I did not
+  - url: https://github.com/OpenNMS/helm-charts.git
+    start_path: docs
+    branches:
+      - main
+      - /^release-.*/
+    tags:
+      - v*
+      - '!v1.0.0'
   - url: https://github.com/OpenNMS/opennms-velocloud-plugin.git
     start_path: docs
     branches:


### PR DESCRIPTION
Named branch after wrong ticket, but added content to the playbook file to add the Helm Charts documentation to the docs.opennms.com website.