### PR TITLE
DP-60: H1 tag missing or empty

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -16,7 +16,42 @@ site:
   keys:
     google_analytics: 'G-WR2RML9P8J'
   start_page: start-page::index.adoc
-  robots: allow
+  robots: |
+    User-agent: *
+    Disallow: /deployment/core/centos-rhel/
+    Disallow: /deployment/core/centos-rhel7/
+    Disallow: /deployment/core/centos-rhel8/
+    Disallow: /deployment/core/centos-rhel9/
+    Disallow: /deployment/core/debian-ubuntu/
+    Disallow: /deployment/core/debian/
+    Disallow: /deployment/core/docker/
+    Disallow: /deployment/core/message-broker/
+    Disallow: /deployment/core/ubuntu/
+    Disallow: /deployment/minion/centos-rhel7/
+    Disallow: /deployment/minion/centos-rhel8/
+    Disallow: /deployment/minion/centos-rhel9/
+    Disallow: /deployment/minion/debian/
+    Disallow: /deployment/minion/docker/
+    Disallow: /deployment/minion/message-broker/
+    Disallow: /deployment/minion/ubuntu/
+    Disallow: /deployment/opentracing/core.adoc
+    Disallow: /deployment/opentracing/minion.adoc
+    Disallow: /deployment/opentracing/sentinel.adoc
+    Disallow: /deployment/repos/rhel-centos/
+    Disallow: /deployment/sentinel/runtime/centos-rhel/
+    Disallow: /deployment/sentinel/runtime/centos-rhel7/
+    Disallow: /deployment/sentinel/runtime/centos-rhel8/
+    Disallow: /deployment/sentinel/runtime/centos-rhel9/
+    Disallow: /deployment/sentinel/runtime/debian-ubuntu/
+    Disallow: /deployment/sentinel/runtime/debian/
+    Disallow: /deployment/sentinel/runtime/ubuntu/
+    Disallow: /deployment/upgrade/backup/centos-rhel8/
+    Disallow: /deployment/upgrade/backup/debian-ubuntu/
+    Disallow: /deployment/upgrade/debian/
+    Disallow: /deployment/upgrade/restore/centos-rhel8/
+    Disallow: /deployment/upgrade/restore/debian-ubuntu/
+    Disallow: /deployment/upgrade/rhel/
+    Disallow: /deployment/deployment/time-sync.adoc
 content:
   sources:
   # Generic start page

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -18,7 +18,7 @@ site:
   start_page: start-page::index.adoc
   robots: |
     User-agent: *
-    Disallow: /deployment/core/centos-rhel/
+    Disallow: */*/deployment/core/centos-rhel/
     Disallow: /deployment/core/centos-rhel7/
     Disallow: /deployment/core/centos-rhel8/
     Disallow: /deployment/core/centos-rhel9/

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -16,51 +16,53 @@ site:
   keys:
     google_analytics: 'G-WR2RML9P8J'
   start_page: start-page::index.adoc
+  # the wildcarded directories will exclude everything in that path, so be aware when adding new files that do have h1 to those directories. Wildcards used to allow for Meridian/Horizon and different versions of each.
   robots: |
     User-agent: *
-    Disallow: */*/deployment/core/centos-rhel/
-    Disallow: /deployment/core/centos-rhel7/
-    Disallow: /deployment/core/centos-rhel8/
-    Disallow: /deployment/core/centos-rhel9/
-    Disallow: /deployment/core/debian-ubuntu/
-    Disallow: /deployment/core/debian/
-    Disallow: /deployment/core/docker/
-    Disallow: /deployment/core/message-broker/
-    Disallow: /deployment/core/ubuntu/
-    Disallow: /deployment/minion/centos-rhel7/
-    Disallow: /deployment/minion/centos-rhel8/
-    Disallow: /deployment/minion/centos-rhel9/
-    Disallow: /deployment/minion/debian/
-    Disallow: /deployment/minion/docker/
-    Disallow: /deployment/minion/message-broker/
-    Disallow: /deployment/minion/ubuntu/
-    Disallow: /deployment/opentracing/core.adoc
-    Disallow: /deployment/opentracing/minion.adoc
-    Disallow: /deployment/opentracing/sentinel.adoc
-    Disallow: /deployment/repos/rhel-centos/
-    Disallow: /deployment/sentinel/runtime/centos-rhel/
-    Disallow: /deployment/sentinel/runtime/centos-rhel7/
-    Disallow: /deployment/sentinel/runtime/centos-rhel8/
-    Disallow: /deployment/sentinel/runtime/centos-rhel9/
-    Disallow: /deployment/sentinel/runtime/debian-ubuntu/
-    Disallow: /deployment/sentinel/runtime/debian/
-    Disallow: /deployment/sentinel/runtime/ubuntu/
-    Disallow: /deployment/upgrade/backup/centos-rhel8/
-    Disallow: /deployment/upgrade/backup/debian-ubuntu/
-    Disallow: /deployment/upgrade/debian/
-    Disallow: /deployment/upgrade/restore/centos-rhel8/
-    Disallow: /deployment/upgrade/restore/debian-ubuntu/
-    Disallow: /deployment/upgrade/rhel/
-    Disallow: /deployment/deployment/time-sync.adoc
-    Disallow: /operation/deep-dive/device-config-backup/centos-rhel/
-    Disallow: /operation/deep-dive/device-config-backup/debian-ubuntu/
-    Disallow: /operation/deep-dive/sentinel/message-broker/
-    Disallow: /operation/deep-dive/sentinel/ipfix.adoc
-    Disallow: /operation/deep-dive/sentinel/netflow5.adoc
-    Disallow: /operation/deep-dive/sentinel/netflow9.adoc
-    Disallow: /operation/deep-dive/sentinel/sflow.adoc
-    Disallow: /reference/configuration/firewall/centos-rhel/
-    Disallow: /reference/configuration/firewall/debian-ubuntu/
+    Disallow: /*/*/deployment/core/centos-rhel/
+    Disallow: /*/*/deployment/core/centos-rhel7/
+    Disallow: /*/*/deployment/core/centos-rhel8/
+    Disallow: /*/*/deployment/core/centos-rhel9/
+    Disallow: /*/*/deployment/core/debian-ubuntu/
+    Disallow: /*/*/deployment/core/debian/
+    Disallow: /*/*/deployment/core/docker/
+    Disallow: /*/*/deployment/core/message-broker/
+    Disallow: /*/*/deployment/core/ubuntu/
+    Disallow: /*/*/deployment/minion/centos-rhel7/
+    Disallow: /*/*/deployment/minion/centos-rhel8/
+    Disallow: /*/*/deployment/minion/centos-rhel9/
+    Disallow: /*/*/deployment/minion/debian/
+    Disallow: /*/*/deployment/minion/docker/
+    Disallow: /*/*/deployment/minion/message-broker/
+    Disallow: /*/*/deployment/minion/ubuntu/
+    Disallow: /*/*/deployment/opentracing/core.adoc
+    Disallow: /*/*/deployment/opentracing/minion.adoc
+    Disallow: /*/*/deployment/opentracing/sentinel.adoc
+    Disallow: /*/*/deployment/repos/rhel-centos/
+    Disallow: /*/*/deployment/sentinel/runtime/centos-rhel/
+    Disallow: /*/*/deployment/sentinel/runtime/centos-rhel7/
+    Disallow: /*/*/deployment/sentinel/runtime/centos-rhel8/
+    Disallow: /*/*/deployment/sentinel/runtime/centos-rhel9/
+    Disallow: /*/*/deployment/sentinel/runtime/debian-ubuntu/
+    Disallow: /*/*/deployment/sentinel/runtime/debian/
+    Disallow: /*/*/deployment/sentinel/runtime/ubuntu/
+    Disallow: /*/*/deployment/upgrade/backup/centos-rhel8/
+    Disallow: /*/*/deployment/upgrade/backup/debian-ubuntu/
+    Disallow: /*/*/deployment/upgrade/debian/
+    Disallow: /*/*/deployment/upgrade/restore/centos-rhel8/
+    Disallow: /*/*/deployment/upgrade/restore/debian-ubuntu/
+    Disallow: /*/*/deployment/upgrade/rhel/
+    Disallow: /*/*/deployment/deployment/time-sync.adoc
+    Disallow: /*/*/operation/deep-dive/device-config-backup/centos-rhel/
+    Disallow: /*/*/operation/deep-dive/device-config-backup/debian-ubuntu/
+    Disallow: /*/*/operation/deep-dive/sentinel/message-broker/
+    Disallow: /*/*/operation/deep-dive/sentinel/ipfix.adoc
+    Disallow: /*/*/operation/deep-dive/sentinel/netflow5.adoc
+    Disallow: /*/*/operation/deep-dive/sentinel/netflow9.adoc
+    Disallow: /*/*/operation/deep-dive/sentinel/sflow.adoc
+    Disallow: /*/*/reference/configuration/firewall/centos-rhel/
+    Disallow: /*/*/reference/configuration/firewall/debian-ubuntu/
+    Disallow: /opennmshelmcharts/*/installation/os/
 content:
   sources:
   # Generic start page

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -52,6 +52,15 @@ site:
     Disallow: /deployment/upgrade/restore/debian-ubuntu/
     Disallow: /deployment/upgrade/rhel/
     Disallow: /deployment/deployment/time-sync.adoc
+    Disallow: /operation/deep-dive/device-config-backup/centos-rhel/
+    Disallow: /operation/deep-dive/device-config-backup/debian-ubuntu/
+    Disallow: /operation/deep-dive/sentinel/message-broker/
+    Disallow: /operation/deep-dive/sentinel/ipfix.adoc
+    Disallow: /operation/deep-dive/sentinel/netflow5.adoc
+    Disallow: /operation/deep-dive/sentinel/netflow9.adoc
+    Disallow: /operation/deep-dive/sentinel/sflow.adoc
+    Disallow: /reference/configuration/firewall/centos-rhel/
+    Disallow: /reference/configuration/firewall/debian-ubuntu/
 content:
   sources:
   # Generic start page


### PR DESCRIPTION
DP-60: H1 tag missing or empty - added items to "disallow" list to improve SEO. Many pages do not have an h1 as they are used in tab block content where the `include` syntax does not allow for h1s. Not sure this will work, but ... 