### PR TITLE
DP-42: DOC: Update Antora files for HS docs build

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -71,6 +71,11 @@ content:
     start_path: docs
     branches:
       - main
+  - url: https://github.com/OpenNMS-Cloud/lokahi.git
+    start_path: docs
+    branches:
+      - develop
+      - /^release-.*/
   - url: https://github.com/OpenNMS/opennms-velocloud-plugin.git
     start_path: docs
     branches:


### PR DESCRIPTION
Updated the docs.opennms.com file to add lokahi docs to the docs website.