### PR TITLE
DP-81: Add pages missing H1 to disallow list in docs.opennms.com

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -60,6 +60,10 @@ site:
     Disallow: /*/*/operation/deep-dive/sentinel/netflow5.adoc
     Disallow: /*/*/operation/deep-dive/sentinel/netflow9.adoc
     Disallow: /*/*/operation/deep-dive/sentinel/sflow.adoc
+    Disallow: /*/*/operation/deep-dive/device-config-backup/dcb-accounts/aruba-os.adoc
+    Disallow: /*/*/operation/deep-dive/device-config-backup/dcb-accounts/aruba-oscx.adoc
+    Disallow: /*/*/operation/deep-dive/device-config-backup/dcb-accounts/cisco-ios.adoc
+    Disallow: /*/*/operation/deep-dive/device-config-backup/dcb-accounts/juniper.adoc
     Disallow: /*/*/reference/configuration/firewall/centos-rhel/
     Disallow: /*/*/reference/configuration/firewall/debian-ubuntu/
     Disallow: /opennmshelmcharts/*/installation/os/


### PR DESCRIPTION
updated "disallow" list to add new files that do not have H1s to avoid SEO issues.
Merge after https://github.com/OpenNMS/opennms/pull/6594