### PR TITLE
Adding circleci_ip_ranges for whitelisting for safer data transfer. Adding web03.opennms.com to the syncing.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
             - project/public
             - project/build
   publish-docs:
+    circleci_ip_ranges: true
     executor: publish-executor
     steps:
       - add_ssh_keys:
@@ -54,10 +55,12 @@ jobs:
           name: Add SSH server fingerprint
           command: |
             echo 'docs.opennms.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMsc8yB7l3htLVhh7LEOcbxV1lus/bO5cc9BOX+2EEBtsbsPMSZVELTN1R1wFS/6watgPDwFcswfD3lUe8ymxZo=' >> ~/.ssh/known_hosts
+            echo 'web03.opennms.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPjI6KGxejlMooBADWlnhAq0HhcvSQDcJMfSgF3eRrDc29gWyzl8ET6WGPDpaw8XTnUNuVQmXW8G14Zs25CbDEE=' >> ~/.ssh/known_hosts
       - run:
           name: Push content to the web server
           command: |
             rsync -a --delete -e ssh public/ circleci@docs.opennms.com:/var/www/docs.opennms.com/htdocs
+            rsync -a --delete -e ssh public/ circleci@web03.opennms.com:/var/www/docs.opennms.com/htdocs
 
 workflows:
   # Triggered by every commit to this repository


### PR DESCRIPTION
A new web server has been deployed to host docs.opennms.com. These changes add `circleci_ip_ranges` (see: https://circleci.com/docs/ip-ranges/) and add web03.opennms.com for syncing.