### PR TITLE
NMS-17870: Add Zenith documentation to build

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -121,6 +121,11 @@ content:
     branches:
       - develop
       - /^release-.*/
+  - url: https://GITHUB_PRIME_TOKEN@github.com/OpenNMS-Cloud/zenith.git
+    start_path: docs
+    branches:
+      - develop
+      - /^release-.*/
   - url: https://github.com/OpenNMS/opennms-velocloud-plugin.git
     start_path: docs
     branches:


### PR DESCRIPTION
Adding Zenith documentation to the build.

Jira: https://opennms.atlassian.net/browse/NMS-17870