### PR TITLE
LOK-3293: Add Zenith to documentation

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -121,6 +121,11 @@ content:
     branches:
       - develop
       - /^release-.*/
+  - url: https://GITHUB_PRIME_TOKEN@github.com/OpenNMS-Cloud/zenith.git
+    start_path: docs
+    branches:
+      - develop
+      - /^release-.*/
   - url: https://github.com/OpenNMS/opennms-velocloud-plugin.git
     start_path: docs
     branches:


### PR DESCRIPTION
Adding Zenith docs to documentation build.

The Zenith documentation has been updated to display correctly, so we can now add them to the official documentation build.

References:

https://opennms.atlassian.net/browse/LOK-3293

https://opennms.atlassian.net/browse/LOK-3281