### PR TITLE
docs: Remove Zenith and Lokahi/Cloud from docs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -116,16 +116,6 @@ content:
       - '!v2.0.0.alpha0' # same SNAPSHOT version as another branch
       - '!v1.1.1' # Tag v1.1.1 has version number 1.1.1-SNAPSHOT use v1.1.1-doc instead
       - '!v1.1.1-rebuild' # I thought I needed to remake the debs, but I did not
-  - url: https://GITHUB_PRIME_TOKEN@github.com/OpenNMS-Cloud/lokahi.git
-    start_path: docs
-    branches:
-      - develop
-      - /^release-.*/
-  - url: https://GITHUB_PRIME_TOKEN@github.com/OpenNMS-Cloud/zenith.git
-    start_path: docs
-    branches:
-      - develop
-      - /^release-.*/
   - url: https://github.com/OpenNMS/opennms-velocloud-plugin.git
     start_path: docs
     branches:


### PR DESCRIPTION
The documentation for Zenith is empty right now. It was added to make sure the documentation workflow is working as expected. We can add it again as soon we have documentation we can publish.

I have also removed Lokahi/Cloud from the docs, because we have removed all traces from Lokahi/Cloud and links in the docs are going to the GitHub wiki page which ends up in 404 not found pages.