### PR TITLE
docs: Only release docs in maintenance window

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   docs-executor:
     docker:
-      - image: opennms/antora:3.1.1-b8850
+      - image: opennms/antora:3.1.12-b10680
   publish-executor:
     docker:
       - image: circleci/buildpack-deps:focal

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 
 SHELL                := /bin/bash -o nounset -o pipefail -o errexit
 WORKING_DIRECTORY    := $(shell pwd)
-DOCKER_ANTORA_IMAGE  := opennms/antora:3.1.1-b8850
+DOCKER_ANTORA_IMAGE  := opennms/antora:3.1.12-b10680
 SITE_FILE            := antora-playbook.yml
 
 help:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -75,27 +75,13 @@ content:
   - url: https://github.com/OpenNMS/opennms.git
     start_path: docs
     branches:
-      - 'master-*'
-      - '!master-29'
-      - '!master-28'
-      - '!master-27'
-      - '!master-26'
-      - '!master-25'
-      - '!master-24'
-      - '!master-23'
-      - '!master-22'
-      - '!master-21'
-      - '!master-20'
+      - 'master-34'
   - url: https://GITHUB_PRIME_TOKEN@github.com/OpenNMS/opennms-prime.git
     start_path: docs
     branches:
-      - 'master-*'
-      - '!master-2020'
-      - '!master-2019'
-      - '!master-2018'
-      - '!master-2017'
-      - '!master-2016'
-      - '!master-2015'
+      - 'master-2024'
+      - 'master-2023'
+      - 'master-2022'
   # embedding empty credentials in the URL disables the Edit this Page link for any page created from this repository
   - url: https://github.com/opennms/grafana-plugin.git
     start_path: docs

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -91,7 +91,6 @@ content:
   - url: https://github.com/OpenNMS/alec.git
     start_path: docs
     branches:
-      - develop
       - /^release-.*/
     tags:
       - v*
@@ -104,16 +103,13 @@ content:
       - '!v1.1.1-rebuild' # I thought I needed to remake the debs, but I did not
   - url: https://github.com/OpenNMS/opennms-velocloud-plugin.git
     start_path: docs
-    branches:
-      - main
-      - /^release-.*/
+    branches: ~
     tags:
       - v*
       - '!v1.0.0'
   - url: https://GITHUB_PRIME_TOKEN@github.com/OpenNMS/opennms-servicenow-plugin.git
     start_path: docs
     branches:
-      - main
       - /^release-.*/
     tags:
       - v*
@@ -127,7 +123,7 @@ content:
       - '!release-1.0*'
   - url: https://github.com/OpenNMS/opennms-js.git
     start_path: docs-src
-    branches: develop
+    branches: ~
     tags:
     - v*
     - '!v0.*'

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -102,12 +102,6 @@ content:
       - '!v2.0.0.alpha0' # same SNAPSHOT version as another branch
       - '!v1.1.1' # Tag v1.1.1 has version number 1.1.1-SNAPSHOT use v1.1.1-doc instead
       - '!v1.1.1-rebuild' # I thought I needed to remake the debs, but I did not
-  - url: https://github.com/OpenNMS/opennms-velocloud-plugin.git
-    start_path: docs
-    branches: ~
-    tags:
-      - v*
-      - '!v1.0.0'
   - url: https://GITHUB_PRIME_TOKEN@github.com/OpenNMS/opennms-servicenow-plugin.git
     start_path: docs
     branches: ~

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -88,6 +88,7 @@ content:
     branches: ~
     tags:
       - 'v12*'
+      - 'v9*'
   - url: https://github.com/OpenNMS/alec.git
     start_path: docs
     branches:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -87,6 +87,7 @@ content:
     start_path: docs
     branches:
       - 'main-*'
+      - '!main-8'
       - '!main-7'
   - url: https://github.com/OpenNMS/alec.git
     start_path: docs

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -75,20 +75,19 @@ content:
   - url: https://github.com/OpenNMS/opennms.git
     start_path: docs
     branches:
-      - 'master-34'
+      - 'master-35'
   - url: https://GITHUB_PRIME_TOKEN@github.com/OpenNMS/opennms-prime.git
     start_path: docs
     branches:
+      - 'master-2025'
       - 'master-2024'
       - 'master-2023'
-      - 'master-2022'
   # embedding empty credentials in the URL disables the Edit this Page link for any page created from this repository
   - url: https://github.com/opennms/grafana-plugin.git
     start_path: docs
-    branches:
-      - 'main-*'
-      - '!main-8'
-      - '!main-7'
+    branches: ~
+    tags:
+      - 'v12*'
   - url: https://github.com/OpenNMS/alec.git
     start_path: docs
     branches:
@@ -110,8 +109,7 @@ content:
       - '!v1.0.0'
   - url: https://GITHUB_PRIME_TOKEN@github.com/OpenNMS/opennms-servicenow-plugin.git
     start_path: docs
-    branches:
-      - /^release-.*/
+    branches: ~
     tags:
       - v*
       - '!v1.0.0'


### PR DESCRIPTION
To make it inherently clear what versions are supported, we should only publish documentation for versions that are supported on docs.opennms.com. The End of Maintenance (EOM) versions should go to vault.opennms.com.

**Before:**
<img width="272" height="803" alt="Screenshot 2025-10-01 at 17 09 03" src="https://github.com/user-attachments/assets/15147e4e-98cc-4e50-9387-1675a9359f13" />

**After:**
<img width="272" height="677" alt="Screenshot 2025-10-01 at 17 07 39" src="https://github.com/user-attachments/assets/82c65792-b8e3-41c5-b919-a22e2d8a4b61" />


## Reviewer Hint

* Removed unreleased branches for SNAPSHOT releases.
* Removed Grafana Plugin release from version 8 which adds it as HELM
* We have dirty releases which gives us these `-SNAPSHOT` versions in-between. The version number wasn't applied and it affects:
  * Alec 3.0.2-SNAPSHOT which is the doc for 3.0.2
  * OpenNMS.js 2.5.6-SNAPSHOT which is the doc for 2.5.6

